### PR TITLE
bug(#1): Add VM module with socket connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod vm;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,0 +1,13 @@
+use tokio::net::UnixStream;
+
+pub mod vm_socket;
+
+pub struct VM {
+    stream: UnixStream,
+}
+
+impl VM {
+    pub fn new(stream: UnixStream) -> Self {
+        Self { stream }
+    }
+}

--- a/src/vm/vm_socket/mod.rs
+++ b/src/vm/vm_socket/mod.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+
+use anyhow::Result;
+use tokio::net::UnixSocket;
+
+use crate::vm::VM;
+
+pub struct VMSocket {
+    socket: UnixSocket,
+}
+
+impl VMSocket {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            socket: UnixSocket::new_stream()?,
+        })
+    }
+
+    pub async fn connect<P: AsRef<Path>>(self, path: P) -> Result<VM> {
+        Ok(VM::new(self.socket.connect(path).await?))
+    }
+}


### PR DESCRIPTION
This commit introduces the VM module, which includes the core VM struct and functionality for connecting to a VM via Unix sockets. The `VMSocket` struct manages the socket connection and establishes a stream with the VM.