### PR TITLE
bug(#21): Bump crate version to 0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firecracker-sdk"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker-sdk"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2024"
 authors = [ "morphqdd <github.com/morphqdd>" ]
 description = "SDK for working with Firecracker MicroVM using the Rust programming language"


### PR DESCRIPTION
This commit bumps the crate version from 0.0.0 to 0.0.1