### PR TITLE
bug(#24): Use SPDX license identifier instead of license-file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = [ "morphqdd <github.com/morphqdd>" ]
 description = "SDK for working with Firecracker MicroVM using the Rust programming language"
 repository = "https://github.com/org-0trust/firecracker-sdk"
-license-file = "LICENSE"
+license = "MIT"
 keywords = ["sdk", "aws", "api", "firecracker", "firecracker-sdk"]
 categories = ["api-bindings", "virtualization", "config"]
 


### PR DESCRIPTION
The `license-file` manifest key is deprecated. This commit switches to `license` using the SPDX license identifier