### PR TITLE
bug(#32): Bump firecracker-sdk version to 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "firecracker-sdk"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firecracker-sdk"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = [ "morphqdd <github.com/morphqdd>" ]
 description = "SDK for working with Firecracker MicroVM using the Rust programming language"


### PR DESCRIPTION
This commit updates the firecracker-sdk crate version in both Cargo.toml and Cargo.lock