### PR TITLE
bug(#38): Corrected doc-test to prevent compilation

### DIFF
--- a/src/firecracker/firercracker_process/firecracker_startup/mod.rs
+++ b/src/firecracker/firercracker_process/firecracker_startup/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 /// Note: Firecracker must be installed globally.
 ///
 /// Exemple:
-/// ```no_run
+/// ```no_compile
 /// let startup = FirecrackerStartup::new()
 ///     .api_socket("/tmp/some.socket");
 /// startup.start().unwrap();

--- a/src/firecracker/mod.rs
+++ b/src/firecracker/mod.rs
@@ -11,7 +11,7 @@ pub mod firercracker_process;
 /// A structure that allows you to work safely with VMs
 ///
 /// Exemple:
-/// ```no_run
+/// ```no_compile
 /// let vm_process = FirecrackerStartup::new()
 ///     .api_sock("/tmp/some.socket")
 ///     .start().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A ***Non-official*** library for easy work with FirecrackerVM from Rust.
 //!
 //! Exemple:
-//! ```no_run
+//! ```no_compile
 //! let vm_process = FirecrackerStartup::new()
 //!     .api_sock("/tmp/some.socket")
 //!     .start().unwrap();


### PR DESCRIPTION
The code examples in the documentation were marked as `no_run` which means that they're not actually tested for compilation, this commit will mark them as `no_compile`