### PR TITLE
bug(#45): Update examples to use async `start()` and builder pattern

### DIFF
--- a/src/api/startup/mod.rs
+++ b/src/api/startup/mod.rs
@@ -17,9 +17,11 @@ use crate::{
 ///
 /// Exemple:
 /// ```no_compile
-/// let startup = FirecrackerStartup::new()
-///     .api_socket("/tmp/some.socket");
-/// startup.start().unwrap();
+/// let process = FirecrackerStartup::new()
+///     .set_api_socket("/tmp/some.socket")
+///     .download_rootfs(true)
+///     .download_kernel(true)
+///     .start().await.unwrap();
 /// ```
 #[derive(Serialize)]
 pub struct FirecrackerStartup {
@@ -38,7 +40,7 @@ impl FirecrackerStartup {
         }
     }
 
-    /// Adds the --api-sock startup argument with the path to the unix socket
+    /// Set the --api-sock startup argument with the path to the unix socket
     ///
     /// Note: For the best documentation, please refer to [here](https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md).
     pub fn set_api_socket<P: AsRef<Path>>(mut self, path: P) -> Self {

--- a/src/infrastructure/connection/stream/mod.rs
+++ b/src/infrastructure/connection/stream/mod.rs
@@ -6,16 +6,6 @@ use tokio::{
 };
 
 /// A structure that allows you to work safely with VMs
-///
-/// Exemple:
-/// ```no_compile
-/// let vm_process = FirecrackerStartup::new()
-///     .api_sock("/tmp/some.socket")
-///     .start().unwrap();
-///
-/// let firecracker_socket = FirecrackerSocket::new().unwrap();
-/// let firecracker_stream = firecracker_socket.connect("/tmp/some.socket");
-/// ```
 pub(crate) struct Stream {
     stream: UnixStream,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,11 @@
 //!
 //! Exemple:
 //! ```no_compile
-//! let vm_process = FirecrackerStartup::new()
-//!     .api_sock("/tmp/some.socket")
-//!     .start().unwrap();
-//!
-//! let firecracker_socket = FirecrackerSocket::new().unwrap();
-//! let firecracker_stream = firecracker_socket.connect("/tmp/some.socket");
+//! let process = FirecrackerStartup::new()
+//!     .set_api_socket("/tmp/some.socket")
+//!     .download_rootfs(true)
+//!     .download_kernel(true)
+//!     .start().await.unwrap();
 //! ```
 //! Before starting work, we recommend that you familiarize yourself with the official [documentation](https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md).
 


### PR DESCRIPTION
The examples were updated to reflect the async nature of the `start()` method and to properly chain builder methods
Closes #45 